### PR TITLE
Add user registration command and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ Authentication and user management are handled via the **Identity microservice**
 - **Ordering.API** – Order processing with DDD and gRPC
 - **Discount.Grpc** – Microservice for applying discounts
 - **Identity.API** – Handles authentication and JWT token issuing
+- **User.API** – Basic user registration and login endpoints
 - **Gateway** – YARP-based API gateway routing traffic
+
+### User API
+
+`POST /user-service/register` – create a new user account
 
 ---
 
@@ -68,3 +73,4 @@ Authentication and user management are handled via the **Identity microservice**
 git clone https://github.com/yagoscalfoni/EShopMicroservices.git
 cd EShopMicroservices
 docker-compose up --build
+```

--- a/src/Services/User/User.API/Endpoints/RegisterUser.cs
+++ b/src/Services/User/User.API/Endpoints/RegisterUser.cs
@@ -1,0 +1,38 @@
+using User.Application.Users.Commands.RegisterUser;
+
+namespace User.API.Endpoints;
+
+/// <summary>
+/// Request to register a new user.
+/// </summary>
+/// <param name="FirstName">First name of the user.</param>
+/// <param name="LastName">Last name of the user.</param>
+/// <param name="Email">Email address.</param>
+/// <param name="Password">User password.</param>
+public record RegisterUserRequest(string FirstName, string LastName, string Email, string Password);
+
+/// <summary>
+/// Response containing created user information.
+/// </summary>
+/// <param name="Id">Id of the new user.</param>
+/// <param name="Email">Email of the new user.</param>
+public record RegisterUserResponse(Guid Id, string Email);
+
+public class RegisterUser : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/register", async (RegisterUserRequest request, ISender sender) =>
+        {
+            var command = request.Adapt<RegisterUserCommand>();
+            var result = await sender.Send(command);
+            var response = new RegisterUserResponse(result.Id, result.Email);
+            return Results.Created($"/users/{response.Id}", response);
+        })
+        .WithName("RegisterUser")
+        .Produces<RegisterUserResponse>(StatusCodes.Status201Created)
+        .ProducesProblem(StatusCodes.Status400BadRequest)
+        .WithSummary("Register User")
+        .WithDescription("Creates a new user account.");
+    }
+}

--- a/src/Services/User/User.Application/User.Application/Users/Commands/RegisterUser/RegisterUserCommand.cs
+++ b/src/Services/User/User.Application/User.Application/Users/Commands/RegisterUser/RegisterUserCommand.cs
@@ -1,0 +1,24 @@
+using BuildingBlocks.CQRS;
+using FluentValidation;
+
+namespace User.Application.Users.Commands.RegisterUser;
+
+public record RegisterUserCommand(string FirstName, string LastName, string Email, string Password) : ICommand<RegisterUserResult>;
+
+public record RegisterUserResult(Guid Id, string Email);
+
+public class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+{
+    public RegisterUserCommandValidator()
+    {
+        RuleFor(x => x.FirstName).NotEmpty().WithMessage("First name is required");
+        RuleFor(x => x.LastName).NotEmpty().WithMessage("Last name is required");
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(6).WithMessage("Password must be at least 6 characters")
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter")
+            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter")
+            .Matches("[0-9]").WithMessage("Password must contain at least one digit");
+    }
+}

--- a/src/Services/User/User.Application/User.Application/Users/Commands/RegisterUser/RegisterUserHandler.cs
+++ b/src/Services/User/User.Application/User.Application/Users/Commands/RegisterUser/RegisterUserHandler.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography;
+using BuildingBlocks.CQRS;
+using Microsoft.EntityFrameworkCore;
+using User.Application.Data;
+using User.Domain.Exceptions;
+using User.Domain.Models;
+using User.Domain.ValueObjects;
+
+namespace User.Application.Users.Commands.RegisterUser;
+
+public class RegisterUserHandler(IApplicationDbContext dbContext)
+    : ICommandHandler<RegisterUserCommand, RegisterUserResult>
+{
+    public async Task<RegisterUserResult> Handle(RegisterUserCommand command, CancellationToken cancellationToken)
+    {
+        var exists = await dbContext.Users.AnyAsync(u => u.Email == command.Email, cancellationToken);
+        if (exists)
+        {
+            throw new DomainException("Email already registered.");
+        }
+
+        var salt = GenerateSalt();
+        var hash = HashPassword(command.Password, salt);
+
+        var user = User.Domain.Models.User.Create(
+            id: UserId.Of(Guid.NewGuid()),
+            firstName: command.FirstName,
+            lastName: command.LastName,
+            email: command.Email,
+            passwordHash: hash,
+            passwordSalt: salt,
+            createdAt: DateTime.UtcNow
+        );
+
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new RegisterUserResult(user.Id.Value, user.Email);
+    }
+
+    private static string GenerateSalt()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(16);
+        return Convert.ToBase64String(bytes);
+    }
+
+    private static string HashPassword(string password, string salt)
+    {
+        using var pbkdf2 = new Rfc2898DeriveBytes(password, Convert.FromBase64String(salt), 10000, HashAlgorithmName.SHA256);
+        return Convert.ToBase64String(pbkdf2.GetBytes(32));
+    }
+}

--- a/src/Tests/Services.Tests/Services.Tests/RegisterUserValidatorTests.cs
+++ b/src/Tests/Services.Tests/Services.Tests/RegisterUserValidatorTests.cs
@@ -1,0 +1,24 @@
+using User.Application.Users.Commands.RegisterUser;
+
+namespace Services.Tests;
+
+public class RegisterUserValidatorTests
+{
+    [Fact]
+    public void Valid_command_passes()
+    {
+        var validator = new RegisterUserCommandValidator();
+        var cmd = new RegisterUserCommand("John", "Doe", "john@example.com", "Strong1");
+        var result = validator.Validate(cmd);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Invalid_email_fails()
+    {
+        var validator = new RegisterUserCommandValidator();
+        var cmd = new RegisterUserCommand("John", "Doe", "bademail", "Strong1");
+        var result = validator.Validate(cmd);
+        Assert.False(result.IsValid);
+    }
+}

--- a/src/Tests/Services.Tests/Services.Tests/Services.Tests.csproj
+++ b/src/Tests/Services.Tests/Services.Tests/Services.Tests.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../../Services/User/User.Application/User.Application/User.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Basket\" />
     <Folder Include="Catalog\" />
     <Folder Include="Discount\" />

--- a/src/WebApps/Shopping.Web/GlobalUsing.cs
+++ b/src/WebApps/Shopping.Web/GlobalUsing.cs
@@ -1,6 +1,7 @@
 ﻿global using Shopping.Web.Models.Catalog;
 global using Shopping.Web.Models.Basket;
 global using Shopping.Web.Models.Ordering;
+global using Shopping.Web.Models.Register;
 global using Refit;
 global using Shopping.Web.Services;
 global using Microsoft.AspNetCore.Mvc;

--- a/src/WebApps/Shopping.Web/Models/Register/RegisterUserModel.cs
+++ b/src/WebApps/Shopping.Web/Models/Register/RegisterUserModel.cs
@@ -1,0 +1,12 @@
+namespace Shopping.Web.Models.Register;
+
+public class RegisterUserModel
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public record RegisterUserRequest(string FirstName, string LastName, string Email, string Password);
+public record RegisterUserResponse(Guid Id, string Email);

--- a/src/WebApps/Shopping.Web/Pages/Login.cshtml
+++ b/src/WebApps/Shopping.Web/Pages/Login.cshtml
@@ -43,6 +43,9 @@
                         <i class="fa fa-apple"></i> Login com Apple
                     </button>
                 </div>
+                <p class="mt-3 text-center">
+                    <a asp-page="/Register">Criar nova conta</a>
+                </p>
             </form>
         </div>
     </div>

--- a/src/WebApps/Shopping.Web/Pages/Register.cshtml
+++ b/src/WebApps/Shopping.Web/Pages/Register.cshtml
@@ -1,0 +1,34 @@
+@page
+@model Shopping.Web.Pages.RegisterModel
+@{
+    ViewData["Title"] = "Register";
+}
+
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <h2 class="text-center">Register</h2>
+            <hr />
+
+            <form method="post">
+                <div class="form-group">
+                    <label for="firstName">First Name</label>
+                    <input type="text" class="form-control" id="firstName" name="RegisterData.FirstName" required />
+                </div>
+                <div class="form-group">
+                    <label for="lastName">Last Name</label>
+                    <input type="text" class="form-control" id="lastName" name="RegisterData.LastName" required />
+                </div>
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input type="email" class="form-control" id="email" name="RegisterData.Email" required />
+                </div>
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" class="form-control" id="password" name="RegisterData.Password" required />
+                </div>
+                <button type="submit" class="btn btn-primary btn-block">Register</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/WebApps/Shopping.Web/Pages/Register.cshtml.cs
+++ b/src/WebApps/Shopping.Web/Pages/Register.cshtml.cs
@@ -1,0 +1,34 @@
+namespace Shopping.Web.Pages;
+
+public class RegisterModel : PageModel
+{
+    private readonly IUserService _userService;
+    private readonly ILogger<RegisterModel> _logger;
+
+    public RegisterModel(IUserService userService, ILogger<RegisterModel> logger)
+    {
+        _userService = userService;
+        _logger = logger;
+    }
+
+    [BindProperty]
+    public RegisterUserModel RegisterData { get; set; } = new RegisterUserModel();
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid) return Page();
+
+        try
+        {
+            var request = new RegisterUserRequest(RegisterData.FirstName, RegisterData.LastName, RegisterData.Email, RegisterData.Password);
+            await _userService.RegisterUser(request);
+            return RedirectToPage("/Login");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error registering user");
+            ModelState.AddModelError(string.Empty, "Registration failed");
+            return Page();
+        }
+    }
+}

--- a/src/WebApps/Shopping.Web/Services/IUserService.cs
+++ b/src/WebApps/Shopping.Web/Services/IUserService.cs
@@ -4,8 +4,13 @@
     {
         [Post("/user-service/authenticate")]
         Task<AuthenticateUserResponse> AuthenticateUser([Body] AuthenticateUserRequest request);
+
+        [Post("/user-service/register")]
+        Task<RegisterUserResponse> RegisterUser([Body] RegisterUserRequest request);
     }
 
     public record AuthenticateUserRequest(string Email, string Password);
     public record AuthenticateUserResponse(string Token, string Name);
+    public record RegisterUserRequest(string FirstName, string LastName, string Email, string Password);
+    public record RegisterUserResponse(Guid Id, string Email);
 }


### PR DESCRIPTION
## Summary
- implement `RegisterUser` command and handler with password hashing
- expose `/register` endpoint in **User.API**
- document the new microservice and fix the README code block
- add Razor Pages screen for registering new users
- create unit tests for the validator

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520070948c8320b5027b507a26e099