### PR TITLE
Migrate messaging to Azure Service Bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛒 EShopMicroservices
 
-A fully modular, cloud-native **e-commerce backend** application built with **.NET 8**, implementing real-world microservices architecture using best practices such as **DDD**, **CQRS**, **Clean Architecture**, **JWT Authentication**, and asynchronous messaging with **RabbitMQ**.
+A fully modular, cloud-native **e-commerce backend** application built with **.NET 8**, implementing real-world microservices architecture using best practices such as **DDD**, **CQRS**, **Clean Architecture**, **JWT Authentication**, and asynchronous messaging with **Azure Service Bus**.
 
 ---
 
@@ -21,7 +21,7 @@ It provides a solid foundation for any enterprise-level distributed system with 
 - ✅ **JWT-based Authentication** via Identity microservice
 - ✅ **API Gateway** using YARP Reverse Proxy
 - ✅ **Sync Communication** with **gRPC**
-- ✅ **Async Communication** with **RabbitMQ + MassTransit**
+- ✅ **Async Communication** with **Azure Service Bus + MassTransit**
 - ✅ **Docker & Docker Compose** for containerized orchestration
 - ✅ **Health Checks**, **OpenTelemetry**, and observability practices
 
@@ -39,7 +39,7 @@ Authentication and user management are handled via the **Identity microservice**
 |---------------------------|-------------------------------------------------------------------------------|
 | **Framework**             | .NET 8, ASP.NET Core Minimal APIs, Razor Pages, C# 12                        |
 | **API Gateway**           | YARP (Yet Another Reverse Proxy)                                             |
-| **Messaging**             | RabbitMQ + MassTransit                                                       |
+| **Messaging**             | Azure Service Bus + MassTransit                                             |
 | **Sync Communication**    | gRPC                                                                         |
 | **Databases**             | PostgreSQL, Redis, SQLite, SQL Server, Marten (Document DB on PostgreSQL)    |
 | **Libraries**             | MediatR, Mapster, Carter, Refit, FluentValidation, EF Core                   |

--- a/docs/keyvault-setup.md
+++ b/docs/keyvault-setup.md
@@ -8,7 +8,7 @@ Este repositório agora diferencia arquivos de orquestração para cenários de 
    ```bash
    az keyvault create -g <resource-group> -n <key-vault-name>
    az keyvault secret set --vault-name <key-vault-name> --name catalog-db-connection-string --value "Server=<host>;Port=5432;Database=CatalogDb;User Id=<user>;Password=<pwd>;Ssl Mode=Require"
-   az keyvault secret set --vault-name <key-vault-name> --name messagebroker-password --value "<strong-password>"
+   az keyvault secret set --vault-name <key-vault-name> --name messagebroker-connection-string --value "Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<policy>;SharedAccessKey=<key>"
    # Repita para cada secret referenciada em `docker-compose.prod.yml`.
    ```
 
@@ -38,9 +38,7 @@ Este repositório agora diferencia arquivos de orquestração para cenários de 
    USER_DB_PASSWORD=$(az keyvault secret show --vault-name $KEY_VAULT --name user-db-password --query value -o tsv)
    ORDER_DB_PASSWORD=$(az keyvault secret show --vault-name $KEY_VAULT --name order-db-password --query value -o tsv)
 
-   MESSAGEBROKER_HOST=amqp://ecommerce-mq:5672
-   MESSAGEBROKER_USERNAME=$(az keyvault secret show --vault-name $KEY_VAULT --name messagebroker-username --query value -o tsv)
-   MESSAGEBROKER_PASSWORD=$(az keyvault secret show --vault-name $KEY_VAULT --name messagebroker-password --query value -o tsv)
+   MESSAGEBROKER_CONNECTION_STRING=$(az keyvault secret show --vault-name $KEY_VAULT --name messagebroker-connection-string --query value -o tsv)
 
    DISCOUNT_GRPC_URL=https://discount.grpc:8081
    GATEWAY_BASE_URI=http://yarpapigateway:8080

--- a/src/BuildingBlocks/BuildingBlocks.Messaging/BuildingBlocks.Messaging.csproj
+++ b/src/BuildingBlocks/BuildingBlocks.Messaging/BuildingBlocks.Messaging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
+    <PackageReference Include="MassTransit.AzureServiceBus.Core" Version="8.1.3" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/BuildingBlocks.Messaging/MassTransit/Extentions.cs
+++ b/src/BuildingBlocks/BuildingBlocks.Messaging/MassTransit/Extentions.cs
@@ -16,13 +16,8 @@ public static class Extentions
             if (assembly != null)
                 config.AddConsumers(assembly);
 
-            config.UsingRabbitMq((context, configurator) =>
+            config.UsingAzureServiceBus(configuration["MessageBroker:ConnectionString"]!, (context, configurator) =>
             {
-                configurator.Host(new Uri(configuration["MessageBroker:Host"]!), host =>
-                {
-                    host.Username(configuration["MessageBroker:UserName"]);
-                    host.Password(configuration["MessageBroker:Password"]);
-                });
                 configurator.ConfigureEndpoints(context);
             });
         });

--- a/src/Services/Basket/Basket.API/appsettings.json
+++ b/src/Services/Basket/Basket.API/appsettings.json
@@ -7,9 +7,7 @@
     "DiscountUrl": "https://localhost:5052"
   },
   "MessageBroker": {
-    "Host": "amqp://localhost:5672",
-    "UserName": "guest",
-    "Password": "guest"
+    "ConnectionString": "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your_key"
   },
   "Logging": {
     "LogLevel": {

--- a/src/Services/Ordering/Ordering.API/appsettings.json
+++ b/src/Services/Ordering/Ordering.API/appsettings.json
@@ -3,9 +3,7 @@
     "Database": "Server=localhost;Database=OrderDb;User Id=sa;Password=SwN12345678;Encrypt=False;TrustServerCertificate=True"
   },
   "MessageBroker": {
-    "Host": "amqp://localhost:5672",
-    "UserName": "guest",
-    "Password": "guest"
+    "ConnectionString": "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your_key"
   },
   "FeatureManagement": {
     "OrderFullfilment": false

--- a/src/Services/User/User.API/appsettings.json
+++ b/src/Services/User/User.API/appsettings.json
@@ -12,9 +12,7 @@
     "Audience": "https://localhost:5000"
   },
   "MessageBroker": {
-    "Host": "amqp://localhost:5672",
-    "UserName": "guest",
-    "Password": "guest"
+    "ConnectionString": "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your_key"
   },
   "Logging": {
     "LogLevel": {

--- a/src/docker-compose.debug.yml
+++ b/src/docker-compose.debug.yml
@@ -104,19 +104,6 @@ services:
     networks:
       - monitoring_network
 
-  messagebroker:
-    container_name: messagebroker
-    hostname: ecommerce-mq
-    environment:
-      - RABBITMQ_DEFAULT_USER=guest
-      - RABBITMQ_DEFAULT_PASS=guest
-    restart: always
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    networks:
-      - monitoring_network
-
   catalog.api:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
@@ -142,14 +129,11 @@ services:
       - ConnectionStrings__Database=Server=basketdb;Port=5432;Database=BasketDb;User Id=postgres;Password=postgres;Include Error Detail=true
       - ConnectionStrings__Redis=distributedcache:6379
       - GrpcSettings__DiscountUrl=https://discount.grpc:8081
-      - MessageBroker__Host=amqp://ecommerce-mq:5672
-      - MessageBroker__UserName=guest
-      - MessageBroker__Password=guest
+      - MessageBroker__ConnectionString=${MESSAGEBROKER_CONNECTION_STRING:-}
     depends_on:
       - basketdb
       - distributedcache
       - discount.grpc
-      - messagebroker
     ports:
       - "6001:8080"
       - "6061:8081"
@@ -180,13 +164,10 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__Database=Server=orderdb;Database=OrderDb;User Id=sa;Password=SwN12345678;Encrypt=False;TrustServerCertificate=True
-      - MessageBroker__Host=amqp://ecommerce-mq:5672
-      - MessageBroker__UserName=guest
-      - MessageBroker__Password=guest
+      - MessageBroker__ConnectionString=${MESSAGEBROKER_CONNECTION_STRING:-}
       - FeatureManagement__OrderFullfilment=false
     depends_on:
       - orderdb
-      - messagebroker
     ports:
       - "6003:8080"
       - "6063:8081"
@@ -202,12 +183,9 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__Database=Server=userdb;Database=UserDb;User Id=sa;Password=SwN12345678;Encrypt=False;TrustServerCertificate=True
-      - MessageBroker__Host=amqp://ecommerce-mq:5672
-      - MessageBroker__UserName=guest
-      - MessageBroker__Password=guest
+      - MessageBroker__ConnectionString=${MESSAGEBROKER_CONNECTION_STRING:-}
     depends_on:
       - userdb
-      - messagebroker
       - jaeger
       - prometheus
     ports:

--- a/src/docker-compose.prod.yml
+++ b/src/docker-compose.prod.yml
@@ -54,16 +54,6 @@ services:
     networks:
       - monitoring_network
 
-  messagebroker:
-    container_name: messagebroker
-    hostname: ecommerce-mq
-    environment:
-      - RABBITMQ_DEFAULT_USER=${MESSAGEBROKER_USERNAME}
-      - RABBITMQ_DEFAULT_PASS=${MESSAGEBROKER_PASSWORD}
-    restart: always
-    networks:
-      - monitoring_network
-
   catalog.api:
     environment:
       <<: *keyvault_placeholders
@@ -79,14 +69,11 @@ services:
       ConnectionStrings__Database: ${BASKET_DB_CONNECTION_STRING}
       ConnectionStrings__Redis: distributedcache:6379
       GrpcSettings__DiscountUrl: ${DISCOUNT_GRPC_URL}
-      MessageBroker__Host: ${MESSAGEBROKER_HOST}
-      MessageBroker__UserName: ${MESSAGEBROKER_USERNAME}
-      MessageBroker__Password: ${MESSAGEBROKER_PASSWORD}
+      MessageBroker__ConnectionString: ${MESSAGEBROKER_CONNECTION_STRING}
     depends_on:
       - basketdb
       - distributedcache
       - discount.grpc
-      - messagebroker
     networks:
       - monitoring_network
 
@@ -101,13 +88,10 @@ services:
     environment:
       <<: *keyvault_placeholders
       ConnectionStrings__Database: ${ORDER_DB_CONNECTION_STRING}
-      MessageBroker__Host: ${MESSAGEBROKER_HOST}
-      MessageBroker__UserName: ${MESSAGEBROKER_USERNAME}
-      MessageBroker__Password: ${MESSAGEBROKER_PASSWORD}
+      MessageBroker__ConnectionString: ${MESSAGEBROKER_CONNECTION_STRING}
       FeatureManagement__OrderFullfilment: ${FEATURE_MANAGEMENT_ORDERFULFILMENT:-false}
     depends_on:
       - orderdb
-      - messagebroker
     networks:
       - monitoring_network
 
@@ -115,12 +99,9 @@ services:
     environment:
       <<: *keyvault_placeholders
       ConnectionStrings__Database: ${USER_DB_CONNECTION_STRING}
-      MessageBroker__Host: ${MESSAGEBROKER_HOST}
-      MessageBroker__UserName: ${MESSAGEBROKER_USERNAME}
-      MessageBroker__Password: ${MESSAGEBROKER_PASSWORD}
+      MessageBroker__ConnectionString: ${MESSAGEBROKER_CONNECTION_STRING}
     depends_on:
       - userdb
-      - messagebroker
     networks:
       - monitoring_network
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -71,11 +71,6 @@ services:
     networks:
       - monitoring_network
 
-  messagebroker:
-    image: rabbitmq:management
-    networks:
-      - monitoring_network
-
   catalog.api:
     image: ${DOCKER_REGISTRY-}catalogapi
     build:


### PR DESCRIPTION
## Summary
- switch MassTransit transport wiring to Azure Service Bus using a single connection string
- replace RabbitMQ dependencies, configuration, and docker-compose wiring with Azure Service Bus settings
- refresh docs and sample appsettings to reflect the new transport

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695966e8ab148320b8490f5a64ba5708)